### PR TITLE
Add ability to report on required checks that are missing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,11 +118,12 @@ async function main(options: Options) {
 
 	println(
 		result.hasRequiredChecks
-			? "  {green {bold ✓ Checks:} {italic (%s successes, %s failures, %s pending)}}"
-			: "  {red {bold ✗ Checks:} {italic (%s successes, %s failures, %s pending)}}",
+			? "  {green {bold ✓ Checks:} {italic (%s successes, %s failures, %s pending, %s missing)}}"
+			: "  {red {bold ✗ Checks:} {italic (%s successes, %s failures, %s pending, %s missing)}}",
 		result.successChecks.length,
 		result.failureChecks.length + result.errorChecks.length,
 		result.pendingChecks.length,
+		result.missingChecks.length,
 	)
 
 	for (let check of result.successChecks) {
@@ -136,6 +137,9 @@ async function main(options: Options) {
 	}
 	for (let check of result.pendingChecks) {
 		println("    {yellow {bold •} %s pending}", check.name)
+	}
+	for (let check of result.missingChecks) {
+		println("    {red {bold ?} %s missing}", check.name)
 	}
 	println("")
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -77,6 +77,7 @@ export default async function isMergable(opts: Options): Promise<Result> {
 	let failureChecks: { name: string }[] = []
 	let errorChecks: { name: string }[] = []
 	let pendingChecks: { name: string }[] = []
+	let missingChecks: { name: string }[] = []
 
 	let latestReviews: Map<
 		string,
@@ -185,6 +186,17 @@ export default async function isMergable(opts: Options): Promise<Result> {
 			if (!match) {
 				hasRequiredChecks = false
 			}
+
+			let checkInList = successChecks
+				.concat(pendingChecks)
+				.concat(failureChecks)
+				.some(check => {
+					return check.name === checkName
+				})
+			// check not found
+			if (!checkInList) {
+				missingChecks.push({ name: checkName })
+			}
 		}
 	}
 
@@ -227,5 +239,6 @@ export default async function isMergable(opts: Options): Promise<Result> {
 		failureChecks,
 		errorChecks,
 		pendingChecks,
+		missingChecks,
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,4 +36,5 @@ export interface Result {
 	failureChecks: { name: string }[]
 	errorChecks: { name: string }[]
 	pendingChecks: { name: string }[]
+	missingChecks: { name: string }[]
 }


### PR DESCRIPTION
This case comes up when a new check is added via CI, but the branch attempting to merge has not been rebased. 

This will list the check missing that are required. It can be troublesome to understand why it is failing when these checks are not listed and all checks that are listed are shown as passing. 