### PR TITLE
Updates to use pagination for repo status

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -44,7 +44,8 @@ export default async function isMergable(opts: Options): Promise<Result> {
 			repo: opts.repo,
 			pull_number: opts.pullRequest,
 		}),
-		octokit.repos.listStatusesForRef({
+		// this is not ideal, but their  type definition does not allow for passing the object notation
+		octokit.paginate("GET /repos/:owner/:repo/statuses/:ref", {
 			owner: opts.owner,
 			repo: opts.repo,
 			ref: pullRef,
@@ -124,7 +125,8 @@ export default async function isMergable(opts: Options): Promise<Result> {
 		Octokit.ReposListStatusesForRefResponseItem
 	> = new Map()
 
-	for (let status of statuses.data) {
+	// sorry for `as` - paginate returns as any[], so we have to cast this somewhere
+	for (let status of statuses as Octokit.ReposListStatusesForRefResponseItem[]) {
 		let prev = latestStatuses.get(status.context)
 		if (prev && new Date(prev.updated_at) > new Date(status.updated_at)) {
 			continue


### PR DESCRIPTION
We ran into an issue where the default number of statuses returned was not enough to get all statuses for a particular ref. 

Specifically because CircleCI send 3 statuses per job, which meant out 14 statuses overflowed the default `30` limit. 

I could have increases the number of statuses per page, but that felt hacky since we would just continue to be moving that target before we eventually added proper handling of pagination. 